### PR TITLE
Fix function signature mismatches for WebAssembly

### DIFF
--- a/src/fft4g32.c
+++ b/src/fft4g32.c
@@ -9,10 +9,10 @@
 
 #if WITH_CR32
 #include "rdft_t.h"
-static void * null(int length) {return 0; (void)length;}
+static void * null(int length) {(void)length; return 0;}
 static void nothing(void * setup) {(void)setup;}
-static void forward(int length, void * setup, void * H, void * scratch) {lsx_safe_rdft_f(length, 1, (double * ) H); (void)setup; (void)scratch;}
-static void backward(int length, void * setup, void * H, void * scratch) {lsx_safe_rdft_f(length, -1, (double * ) H); (void)setup; (void)scratch;}
+static void forward(int length, void * setup, void * H, void * scratch) {(void)setup; (void)scratch; lsx_safe_rdft_f(length, 1, (double *)H);}
+static void backward(int length, void * setup, void * H, void * scratch) {(void)setup; (void)scratch; lsx_safe_rdft_f(length, -1, (double *)H);}
 static int multiplier(void) {return 2;}
 static void nothing2(int length, void * setup, void * H, void * scratch) {(void)length; (void)setup; (void)H; (void)scratch;}
 static int flags(void) {return 0;}

--- a/src/fft4g32.c
+++ b/src/fft4g32.c
@@ -11,10 +11,10 @@
 #include "rdft_t.h"
 static void * null(int length) {(void)length; return 0;}
 static void nothing(void * setup) {(void)setup;}
-static void forward(int length, void * setup, void * H, void * scratch) {(void)setup; (void)scratch; lsx_safe_rdft_f(length, 1, (double *)H);}
-static void backward(int length, void * setup, void * H, void * scratch) {(void)setup; (void)scratch; lsx_safe_rdft_f(length, -1, (double *)H);}
+static void forward(int length, void * setup, double * H, void * scratch) {(void)setup; (void)scratch; lsx_safe_rdft_f(length, 1, H);}
+static void backward(int length, void * setup, double * H, void * scratch) {(void)setup; (void)scratch; lsx_safe_rdft_f(length, -1, H);}
 static int multiplier(void) {return 2;}
-static void nothing2(int length, void * setup, void * H, void * scratch) {(void)length; (void)setup; (void)H; (void)scratch;}
+static void nothing2(int length, void * setup, double * H, void * scratch) {(void)length; (void)setup; (void)H; (void)scratch;}
 static int flags(void) {return 0;}
 
 fn_t _soxr_rdft32_cb[] = {

--- a/src/fft4g32.c
+++ b/src/fft4g32.c
@@ -9,11 +9,12 @@
 
 #if WITH_CR32
 #include "rdft_t.h"
-static void * null(void) {return 0;}
-static void forward (int length, void * setup, double * H) {lsx_safe_rdft_f(length,  1, H); (void)setup;}
-static void backward(int length, void * setup, double * H) {lsx_safe_rdft_f(length, -1, H); (void)setup;}
+static void * null(int length) {return 0; (void)length;}
+static void nothing(void * setup) {(void)setup;}
+static void forward(int length, void * setup, void * H, void * scratch) {lsx_safe_rdft_f(length, 1, (double * ) H); (void)setup; (void)scratch;}
+static void backward(int length, void * setup, void * H, void * scratch) {lsx_safe_rdft_f(length, -1, (double * ) H); (void)setup; (void)scratch;}
 static int multiplier(void) {return 2;}
-static void nothing(void) {}
+static void nothing2(int length, void * setup, void * H, void * scratch) {(void)length; (void)setup; (void)H; (void)scratch;}
 static int flags(void) {return 0;}
 
 fn_t _soxr_rdft32_cb[] = {
@@ -27,7 +28,7 @@ fn_t _soxr_rdft32_cb[] = {
   (fn_t)_soxr_ordered_convolve_f,
   (fn_t)_soxr_ordered_partial_convolve_f,
   (fn_t)multiplier,
-  (fn_t)nothing,
+  (fn_t)nothing2,
   (fn_t)malloc,
   (fn_t)calloc,
   (fn_t)free,

--- a/src/fft4g32s.c
+++ b/src/fft4g32s.c
@@ -5,10 +5,10 @@
 #include "util32s.h"
 #include "rdft_t.h"
 
-static void * null(int length) {return 0; (void)length;}
+static void * null(int length) {(void)length; return 0;}
 static void nothing(void * setup) {(void)setup;}
-static void forward (int length, void * setup, void * H, void * scratch) {lsx_safe_rdft_f(length,  1, (float*)H); (void)setup; (void)scratch;}
-static void backward(int length, void * setup, void * H, void * scratch) {lsx_safe_rdft_f(length, -1, (float*)H); (void)setup; (void)scratch;}
+static void forward(int length, void * setup, void * H, void * scratch) {(void)setup; (void)scratch; lsx_safe_rdft_f(length, 1, (float*)H);}
+static void backward(int length, void * setup, void * H, void * scratch) {(void)setup; (void)scratch; lsx_safe_rdft_f(length, -1, (float*)H);}
 static int multiplier(void) {return 2;}
 static void nothing2(int length, void * setup, void * H, void * scratch) {(void)length; (void)setup; (void)H; (void)scratch;}
 static int flags(void) {return RDFT_IS_SIMD;}

--- a/src/fft4g32s.c
+++ b/src/fft4g32s.c
@@ -7,10 +7,10 @@
 
 static void * null(int length) {(void)length; return 0;}
 static void nothing(void * setup) {(void)setup;}
-static void forward(int length, void * setup, void * H, void * scratch) {(void)setup; (void)scratch; lsx_safe_rdft_f(length, 1, (float*)H);}
-static void backward(int length, void * setup, void * H, void * scratch) {(void)setup; (void)scratch; lsx_safe_rdft_f(length, -1, (float*)H);}
+static void forward(int length, void * setup, float * H, void * scratch) {(void)setup; (void)scratch; lsx_safe_rdft_f(length, 1, H);}
+static void backward(int length, void * setup, float * H, void * scratch) {(void)setup; (void)scratch; lsx_safe_rdft_f(length, -1, H);}
 static int multiplier(void) {return 2;}
-static void nothing2(int length, void * setup, void * H, void * scratch) {(void)length; (void)setup; (void)H; (void)scratch;}
+static void nothing2(int length, void * setup, float * H, void * scratch) {(void)length; (void)setup; (void)H; (void)scratch;}
 static int flags(void) {return RDFT_IS_SIMD;}
 
 fn_t _soxr_rdft32s_cb[] = {

--- a/src/fft4g32s.c
+++ b/src/fft4g32s.c
@@ -5,11 +5,12 @@
 #include "util32s.h"
 #include "rdft_t.h"
 
-static void * null(void) {return 0;}
-static void nothing(void) {}
-static void forward (int length, void * setup, float * H) {lsx_safe_rdft_f(length,  1, H); (void)setup;}
-static void backward(int length, void * setup, float * H) {lsx_safe_rdft_f(length, -1, H); (void)setup;}
+static void * null(int length) {return 0; (void)length;}
+static void nothing(void * setup) {(void)setup;}
+static void forward (int length, void * setup, void * H, void * scratch) {lsx_safe_rdft_f(length,  1, (float*)H); (void)setup; (void)scratch;}
+static void backward(int length, void * setup, void * H, void * scratch) {lsx_safe_rdft_f(length, -1, (float*)H); (void)setup; (void)scratch;}
 static int multiplier(void) {return 2;}
+static void nothing2(int length, void * setup, void * H, void * scratch) {(void)length; (void)setup; (void)H; (void)scratch;}
 static int flags(void) {return RDFT_IS_SIMD;}
 
 fn_t _soxr_rdft32s_cb[] = {
@@ -23,7 +24,7 @@ fn_t _soxr_rdft32s_cb[] = {
   (fn_t)ORDERED_CONVOLVE_SIMD,
   (fn_t)ORDERED_PARTIAL_CONVOLVE_SIMD,
   (fn_t)multiplier,
-  (fn_t)nothing,
+  (fn_t)nothing2,
   (fn_t)SIMD_ALIGNED_MALLOC,
   (fn_t)SIMD_ALIGNED_CALLOC,
   (fn_t)SIMD_ALIGNED_FREE,

--- a/src/fft4g64.c
+++ b/src/fft4g64.c
@@ -9,10 +9,10 @@
 #if WITH_CR64
 static void * null(int length) {(void)length; return 0;}
 static void nothing(void * setup) {(void)setup;}
-static void forward(int length, void * setup, void * H, void * scratch) {(void)setup; (void)scratch; lsx_safe_rdft(length, 1, (double*)H);}
-static void backward(int length, void * setup, void * H, void * scratch) {(void)setup; (void)scratch; lsx_safe_rdft(length, -1, (double*)H);}
+static void forward(int length, void * setup, double * H, void * scratch) {(void)setup; (void)scratch; lsx_safe_rdft(length, 1, H);}
+static void backward(int length, void * setup, double * H, void * scratch) {(void)setup; (void)scratch; lsx_safe_rdft(length, -1, H);}
 static int multiplier(void) {return 2;}
-static void nothing2(int length, void * setup, void * H, void * scratch) {(void)length; (void)setup; (void)H; (void)scratch;}
+static void nothing2(int length, void * setup, double * H, void * scratch) {(void)length; (void)setup; (void)H; (void)scratch;}
 static int flags(void) {return 0;}
 
 typedef void (* fn_t)(void);

--- a/src/fft4g64.c
+++ b/src/fft4g64.c
@@ -7,10 +7,10 @@
 #include "soxr-config.h"
 
 #if WITH_CR64
-static void * null(int length) {return 0; (void)length;}
+static void * null(int length) {(void)length; return 0;}
 static void nothing(void * setup) {(void)setup;}
-static void forward (int length, void * setup, void * H, void * scratch) {lsx_safe_rdft(length,  1, (double*)H); (void)setup; (void)scratch;}
-static void backward(int length, void * setup, void * H, void * scratch) {lsx_safe_rdft(length, -1, (double*)H); (void)setup; (void)scratch;}
+static void forward(int length, void * setup, void * H, void * scratch) {(void)setup; (void)scratch; lsx_safe_rdft(length, 1, (double*)H);}
+static void backward(int length, void * setup, void * H, void * scratch) {(void)setup; (void)scratch; lsx_safe_rdft(length, -1, (double*)H);}
 static int multiplier(void) {return 2;}
 static void nothing2(int length, void * setup, void * H, void * scratch) {(void)length; (void)setup; (void)H; (void)scratch;}
 static int flags(void) {return 0;}

--- a/src/fft4g64.c
+++ b/src/fft4g64.c
@@ -7,11 +7,12 @@
 #include "soxr-config.h"
 
 #if WITH_CR64
-static void * null(void) {return 0;}
-static void nothing(void) {}
-static void forward (int length, void * setup, double * H) {lsx_safe_rdft(length,  1, H); (void)setup;}
-static void backward(int length, void * setup, double * H) {lsx_safe_rdft(length, -1, H); (void)setup;}
+static void * null(int length) {return 0; (void)length;}
+static void nothing(void * setup) {(void)setup;}
+static void forward (int length, void * setup, void * H, void * scratch) {lsx_safe_rdft(length,  1, (double*)H); (void)setup; (void)scratch;}
+static void backward(int length, void * setup, void * H, void * scratch) {lsx_safe_rdft(length, -1, (double*)H); (void)setup; (void)scratch;}
 static int multiplier(void) {return 2;}
+static void nothing2(int length, void * setup, void * H, void * scratch) {(void)length; (void)setup; (void)H; (void)scratch;}
 static int flags(void) {return 0;}
 
 typedef void (* fn_t)(void);
@@ -26,7 +27,7 @@ fn_t _soxr_rdft64_cb[] = {
   (fn_t)_soxr_ordered_convolve,
   (fn_t)_soxr_ordered_partial_convolve,
   (fn_t)multiplier,
-  (fn_t)nothing,
+  (fn_t)nothing2,
   (fn_t)malloc,
   (fn_t)calloc,
   (fn_t)free,


### PR DESCRIPTION
This PR fixes the mismatch between the function signatures in `fft4g*` and `rdft_t.h`. On most platforms this is not an issue, but some platforms like WebAssembly don't support calls with mismatching function signatures.

This PR is identical to the one I made in the upstream project (chirlu/soxr#13). I made a second PR in this fork because the project seems to be dead since six years and I only intend to use this fix in pyodide/pyodide#5150.